### PR TITLE
Restructure and Nim type wrappers for inq and some inq_dim functions

### DIFF
--- a/src/netcdf.nim
+++ b/src/netcdf.nim
@@ -1,3 +1,6 @@
+import netcdf/dimensions
+export dimensions
+
 import netcdf/error_handler
 
 import netcdf/netcdf_bindings

--- a/src/netcdf.nim
+++ b/src/netcdf.nim
@@ -1,23 +1,17 @@
+import netcdf/error_handler
+
 import netcdf/netcdf_bindings
 export netcdf_bindings
 
+import netcdf/shared_types
+export shared_types
+
 type
-  NetcdfError* = object of CatchableError
-
-  NcId* = distinct cint
-
   OpenMode* = enum
     omNoWrite = NC_NOWRITE # read-only
     omWrite = NC_WRITE
     omShare = NC_SHARE
     omWriteShare = NC_WRITE or NC_SHARE
-
-template handleError(body: untyped) =
-  let retval: cint = body
-  if retval != 0:
-    raise newException(NetcdfError, "Error " & $retval & ": " & $retval.strerror & ". Call: " & body.astToStr)
-
-proc `$`*(ncid: NcId): string = $ncid.int
 
 proc ncOpen*(path: string, mode = omNoWrite): NCid =
   handleError open(path, mode.cint, result.cint)

--- a/src/netcdf.nim
+++ b/src/netcdf.nim
@@ -18,3 +18,8 @@ proc ncOpen*(path: string, mode = omNoWrite): NCid =
 
 proc close*(ncid: NCid) =
   handleError close(ncid.cint)
+
+proc inq*(ncid: NCid): tuple[ndims, nvars, natts, unlimdimid: int] =
+  var ndims, nvars, natts, unlimdimid: cint
+  handleError inq(ncid.cint, ndims, nvars, natts, unlimdimid)
+  (ndims.int, nvars.int, natts.int, unlimdimid.int)

--- a/src/netcdf/dimensions.nim
+++ b/src/netcdf/dimensions.nim
@@ -1,0 +1,31 @@
+import netcdf/[error_handler, netcdf_bindings, shared_types]
+
+# Wrappers with Nim types for the C bindings
+
+proc inqNdims*(ncid: NCId): int =
+  var ndims: cint
+  handleError inqNdims(ncid.cint, ndims)
+  ndims.int
+
+proc inqDimname*(ncid: NCId, dimid: DimId): string =
+  result = newString(NC_MAX_NAME + 1)
+  handleError inqDimname(ncid.cint, dimid.cint, result.cstring)
+  result.setLen(result.cstring.len)
+
+proc inqDimid*(ncid: NCid, name: string): DimId =
+  handleError inqDimid(ncid.cint, name, result.cint)
+
+proc inqDimlen*(ncid: NCId, dimid: DimId): int =
+  var len: csize_t
+  handleError inqDimlen(ncid.cint, dimid.cint, len)
+  len.int
+
+
+# Additional convenience procs
+
+proc inqDimnames*(ncid: NCId): seq[string] =
+  for dimid in 0 ..< inqNdims(ncid):
+    result.add inqDimname(ncid, dimid.DimId)
+
+proc inqDimlen*(ncid: NCId, name: string): int =
+  inqDimlen(ncid, inqDimid(ncid, name))

--- a/src/netcdf/error_handler.nim
+++ b/src/netcdf/error_handler.nim
@@ -1,0 +1,5 @@
+template handleError*(body: untyped) =
+  let retval: cint = body
+  if retval != 0:
+    raise newException(NetcdfError, "Error " & $retval & ": " &
+        $retval.strerror & ". Call: " & body.astToStr)

--- a/src/netcdf/netcdf_bindings.nim
+++ b/src/netcdf/netcdf_bindings.nim
@@ -1064,7 +1064,7 @@ proc abort*(ncid: cint): cint {.importc: "nc_abort", dynlib: libnetcdf.}
 proc close*(ncid: cint): cint {.importc: "nc_close", dynlib: libnetcdf.}
 proc inq*(ncid: cint; ndimsp, nvarsp, nattsp,
     unlimdimidp: var cint): cint {.importc: "nc_inq", dynlib: libnetcdf.}
-proc inq_ndims*(ncid: cint; ndimsp: ptr cint): cint {.importc: "nc_inq_ndims",
+proc inq_ndims*(ncid: cint; ndimsp: var cint): cint {.importc: "nc_inq_ndims",
     dynlib: libnetcdf.}
 proc inq_nvars*(ncid: cint; nvarsp: ptr cint): cint {.importc: "nc_inq_nvars",
     dynlib: libnetcdf.}
@@ -1088,13 +1088,13 @@ proc inq_format_extended*(ncid: cint; formatp: ptr cint; modep: ptr cint): cint 
 
 proc def_dim*(ncid: cint; name: cstring; len: csize_t; idp: ptr cint): cint {.
     importc: "nc_def_dim", dynlib: libnetcdf.}
-proc inq_dimid*(ncid: cint; name: cstring; idp: ptr cint): cint {.
+proc inq_dimid*(ncid: cint; name: cstring; idp: var cint): cint {.
     importc: "nc_inq_dimid", dynlib: libnetcdf.}
 proc inq_dim*(ncid: cint; dimid: cint; name: cstring; lenp: ptr csize_t): cint {.
     importc: "nc_inq_dim", dynlib: libnetcdf.}
 proc inq_dimname*(ncid: cint; dimid: cint; name: cstring): cint {.
     importc: "nc_inq_dimname", dynlib: libnetcdf.}
-proc inq_dimlen*(ncid: cint; dimid: cint; lenp: ptr csize_t): cint {.
+proc inq_dimlen*(ncid: cint; dimid: cint; lenp: var csize_t): cint {.
     importc: "nc_inq_dimlen", dynlib: libnetcdf.}
 proc rename_dim*(ncid: cint; dimid: cint; name: cstring): cint {.
     importc: "nc_rename_dim", dynlib: libnetcdf.}

--- a/src/netcdf/netcdf_bindings.nim
+++ b/src/netcdf/netcdf_bindings.nim
@@ -1062,8 +1062,8 @@ proc enddef*(ncid: cint): cint {.importc: "nc_enddef", dynlib: libnetcdf.}
 proc sync*(ncid: cint): cint {.importc: "nc_sync", dynlib: libnetcdf.}
 proc abort*(ncid: cint): cint {.importc: "nc_abort", dynlib: libnetcdf.}
 proc close*(ncid: cint): cint {.importc: "nc_close", dynlib: libnetcdf.}
-proc inq*(ncid: cint; ndimsp: ptr cint; nvarsp: ptr cint; nattsp: ptr cint;
-         unlimdimidp: ptr cint): cint {.importc: "nc_inq", dynlib: libnetcdf.}
+proc inq*(ncid: cint; ndimsp, nvarsp, nattsp,
+    unlimdimidp: var cint): cint {.importc: "nc_inq", dynlib: libnetcdf.}
 proc inq_ndims*(ncid: cint; ndimsp: ptr cint): cint {.importc: "nc_inq_ndims",
     dynlib: libnetcdf.}
 proc inq_nvars*(ncid: cint; nvarsp: ptr cint): cint {.importc: "nc_inq_nvars",

--- a/src/netcdf/shared_types.nim
+++ b/src/netcdf/shared_types.nim
@@ -3,4 +3,8 @@ type
 
   NcId* = distinct cint
 
+  DimId* = distinct cint
+
 proc `$`*(ncid: NcId): string = $ncid.int
+
+proc `$`*(dimid: DimId): string = $dimid.int

--- a/src/netcdf/shared_types.nim
+++ b/src/netcdf/shared_types.nim
@@ -1,0 +1,6 @@
+type
+  NetcdfError* = object of CatchableError
+
+  NcId* = distinct cint
+
+proc `$`*(ncid: NcId): string = $ncid.int


### PR DESCRIPTION
I want to split the functions for dimensions, variables and attributes into their own modules. That is what the new structure is about. I think it is similar to nimhdf5 but I keep some functions in the main file, at least for now.

The variables and attributes will come in a later commit or PR.

My plan at the moment is to write what I called "Nim type wrappers" for the procs that bind to the C functions, at least some of them, but otherwise keep them the same. Then implement a higher level API on top of that.

I did add a few procs though for added convenience that differ from the C bindings (don't exist there) but are not really the high level API I want to eventually write either. At the moment I put them after a comment in the code.
```nim
# Additional convenience procs

proc inqDimnames*(ncid: NCId): seq[string] =
  for dimid in 0 ..< inqNdims(ncid):
    result.add inqDimname(ncid, dimid.DimId)

proc inqDimlen*(ncid: NCId, name: string): int =
  inqDimlen(ncid, inqDimid(ncid, name))
```
Maybe you have a suggestion on where to put those or how to separate them? Or maybe I should just not do that and come up with a good high level API (which I want to do anyway) and skip these half measures?


I'm not clear on when it is better to use tuple and when object. Specifically in this PR in this proc.
```nim
proc inq*(ncid: NCid): tuple[ndims, nvars, natts, unlimdimid: int] =
  var ndims, nvars, natts, unlimdimid: cint
  handleError inq(ncid.cint, ndims, nvars, natts, unlimdimid)
  (ndims.int, nvars.int, natts.int, unlimdimid.int)
```